### PR TITLE
Fix 404 Error at the admin interface in refinerycms 2.0.4

### DIFF
--- a/lib/refinery/portfolio/engine.rb
+++ b/lib/refinery/portfolio/engine.rb
@@ -16,7 +16,7 @@ module Refinery
           plugin.activity = {
             :class_name => :'refinery/portfolio/gallery'
           }
-          plugin.menu_match = %r{refinery/portfolio(/galleries(/.*)?)?$}
+          plugin.menu_match = %r{refinery/portfolio(/galleries(/.*)?)?(/items(/.*)?)?$}
         end
       end
 


### PR DESCRIPTION
Changed the `menu_match` option to better work on refinerycms 2.0.4 (resolving issue #70)
