### PR TITLE
Special i18n exception handler was causing missing plural exceptions to be raised

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,3 @@
-module I18n
-  def self.just_raise(*args)
-    raise args.first.message
-  end
-end
-
 def setup_environment
   # Configure Rails Environment
   ENV["RAILS_ENV"] ||= 'test'
@@ -22,8 +16,6 @@ def setup_environment
     config.filter_run :focus => true
     config.run_all_when_everything_filtered = true
   end
-
-  ::I18n.exception_handler = :just_raise
 
 end
 


### PR DESCRIPTION
Normally missing plural exceptions are ignored to fall back to the default pluralization rule for English.  The special exception handler suggested in http://guides.rubyonrails.org/i18n.html#using-different-exception-handlers has the unfortunate side-effect of raising missing plural exceptions as well.  In Portfolio this causes five specs to fail.

There is a nice solution mentioned in http://edgeguides.rubyonrails.org/i18n.html#using-different-exception-handlers, but that's edge Rails.
