### PR TITLE
Fix for issue #85

### DIFF
--- a/app/controllers/refinery/portfolio/admin/items_controller.rb
+++ b/app/controllers/refinery/portfolio/admin/items_controller.rb
@@ -23,12 +23,12 @@ module Refinery
         end
 
         def new
-          @item = Item.new(:gallery_id => find_gallery)
+          @item = Item.new(:gallery_id => find_gallery.id)
         end
 
         private
         def find_gallery
-          @gallery = Gallery.find(params[:gallery_id]) if params[:gallery_id]
+          @gallery = Gallery.where(slug: params[:gallery_id]).first if params[:gallery_id]
         end
 
       end


### PR DESCRIPTION
Fix for issue #85 on branch 2-0-stable. 

Changed:
`find_gallery` method to query `Gallery` model by `slug` not `id`
