### PR TITLE
Update refinerycms-acts-as-indexed dependency

### DIFF
--- a/refinerycms-portfolio.gemspec
+++ b/refinerycms-portfolio.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files`.split("\n")
 
   s.add_dependency 'refinerycms-core', '~> 3.0.0'
-  s.add_dependency 'refinerycms-acts-as-indexed', '~> 2.0.0'
+  s.add_dependency 'refinerycms-acts-as-indexed', '~> 3.0.0'
   s.add_dependency 'globalize', ['>= 4.0.0', '< 5.2']
   s.add_dependency 'friendly_id', '~> 5.1.0'
   s.add_dependency 'friendly_id-globalize', '>= 1.0.0.alpha2'


### PR DESCRIPTION
This will be merged after : https://github.com/refinery/refinerycms-acts-as-indexed/pull/8