### PR TITLE
Fix #110 issue. Add :position param to Refinery::Portfolio::Admin::ItemsController

### DIFF
--- a/app/controllers/refinery/portfolio/admin/items_controller.rb
+++ b/app/controllers/refinery/portfolio/admin/items_controller.rb
@@ -31,7 +31,7 @@ module Refinery
 
         private
           def item_params
-            params.require(:item).permit(:title, :caption, :image_id, :gallery_id)
+            params.require(:item).permit(:title, :caption, :image_id, :gallery_id, :position)
           end
 
       end


### PR DESCRIPTION
The problem occurs when a user tries to add an image to existing gallery.

```
Started POST "/refinery/portfolio/galleries/sdsf/items" for ::1 at 2016-01-24 14:38:20 +0600
Processing by Refinery::Portfolio::Admin::ItemsController#create as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"4GEKLQc0KchJXJPA+uzwYa2OPeBr0veThNrtI9MQof0+SGKYV+uX6ld9Rgbvh6BXu83yhXT3s1UKXSDjKyZIcA==", "switch_locale"=>"en", "item"=>{"title"=>"bbb", "caption"=>"<p>bfghfg</p>", "image_id"=>"5", "gallery_id"=>"1"}, "gallery_id"=>"sdsf", "locale"=>:en}
   (0.3ms)  SELECT MAX("refinery_portfolio_items"."position") FROM "refinery_portfolio_items"
  Refinery::Authentication::Devise::User Load (0.4ms)  SELECT  "refinery_authentication_devise_users".* FROM "refinery_authentication_devise_users" WHERE "refinery_authentication_devise_users"."id" = ?  ORDER BY "refinery_authentication_devise_users"."id" ASC LIMIT 1  [["id", 1]]
  Refinery::Authentication::Devise::Role Load (0.9ms)  SELECT "refinery_authentication_devise_roles".* FROM "refinery_authentication_devise_roles" INNER JOIN "refinery_authentication_devise_roles_users" ON "refinery_authentication_devise_roles"."id" = "refinery_authentication_devise_roles_users"."role_id" WHERE "refinery_authentication_devise_roles_users"."user_id" = ?  [["user_id", 1]]
Unpermitted parameter: position
```

After that user sees error as described in #110 . Because app can't sort images by position in `cover_image` method.

```
# Refinery::Portfolio::Gallery
def cover_image
  items.sort_by(&:position).first if items.present?
end
```
